### PR TITLE
Use text inputs for Search component

### DIFF
--- a/app/components/search/index.tsx
+++ b/app/components/search/index.tsx
@@ -22,7 +22,7 @@ export const Search: FC<SearchProps> = ({
 
     <input
       className="search__input"
-      type="search"
+      type="text"
       placeholder={placeholder}
       onChange={onSearchTermChange}
     />


### PR DESCRIPTION
As the PR title states, this swaps `<Search>` input types to be `text` rather than `search`. This gets rid of default browser behaviors such as adding its own icons, etc. which are inconsistent.