### PR TITLE
Add OG image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/nshki/remix-directory/blob/main/public/assets/og.png?raw=true)
+
 # Remix Directory
 
 This is a community-powered directory of [Remix stacks](https://remix.run/stacks).


### PR DESCRIPTION
As the title states, this adds the open graph image to the README for a little nicety when viewing the GitHub repo.